### PR TITLE
Fixing test failure

### DIFF
--- a/csv_importer_test.go
+++ b/csv_importer_test.go
@@ -29,9 +29,9 @@ func TestImportedLoadCorrectData(t *testing.T) {
 		f = "data/test.csv"
 		i = CsvImporter()
 		s = [][]float64{
-			[]float64{0.1, 0.2, 0.3},
-			[]float64{0.4, 0.5, 0.6},
-			[]float64{0.7, 0.8, 0.9},
+			{0.1, 0.2, 0.3},
+			{0.4, 0.5, 0.6},
+			{0.7, 0.8, 0.9},
 		}
 	)
 
@@ -41,7 +41,7 @@ func TestImportedLoadCorrectData(t *testing.T) {
 	}
 
 	if !fsliceEqual(d, s) {
-		t.Error("Imported data mismatch: %v vs %v\n", d, s)
+		t.Errorf("Imported data mismatch: %v vs %v\n", d, s)
 	}
 }
 


### PR DESCRIPTION
go test is currently broken and fails with:

./csv_importer_test.go:44:3: Error call has possible formatting directive %v

Simple little fix to address that.