### PR TITLE
fix dbscan waitgroup panic when multiple workers are used

### DIFF
--- a/dbscan.go
+++ b/dbscan.go
@@ -79,7 +79,7 @@ func (c *dbscanClusterer) Learn(data [][]float64) error {
 	c.l = len(data)
 	c.s = c.numWorkers()
 	c.o = c.s - 1
-	c.f = c.l / c.s
+	c.f = (c.l + c.s - 1) / c.s
 
 	c.d = data
 


### PR DESCRIPTION
Hi, 
I hope this message finds you well. 

I'm raising this PR to fix negative wait group value when DBSCAN is utilising multiple threads.

Issue: 
The division used to calculate c.f takes the floor of the integer value, which may result in the "nearest" function creating more rangeJobs than the number of workers. Consequently, this causes more calls to WaitGroup.Done than WaitGroup.Add, leading to a negative wait group value.

Solution: 
Modify the calculation to use the ceiling of the integer value for c.f. 

Thank you for your time.